### PR TITLE
Trim add command attributes

### DIFF
--- a/src/main/java/seedu/wildwatch/command/AddCommand.java
+++ b/src/main/java/seedu/wildwatch/command/AddCommand.java
@@ -29,9 +29,9 @@ public class AddCommand extends Command {
             throw new IncorrectInputException();
         }
 
-        final String date = matcher.group("date");
-        final String species = matcher.group("species");
-        final String name = matcher.group("name");
+        final String date = matcher.group("date").trim();
+        final String species = matcher.group("species").trim();
+        final String name = matcher.group("name").trim();
         final String remark = matcher.group("remark");
 
         EntryList.addEntry(date, species, name, remark);


### PR DESCRIPTION
Fixes problem with exceptions being thrown when whitespace is present in date (e.g. `D/ 12-12-12`) 