### PR TITLE
Add execute()s to commands

### DIFF
--- a/src/main/java/seedu/wildwatch/command/AddCommand.java
+++ b/src/main/java/seedu/wildwatch/command/AddCommand.java
@@ -22,7 +22,14 @@ public class AddCommand extends Command {
                     + " N/(?<name>[^/]+)"
                     + "(?: R/(?<remark>[^/]+))?");
 
-    public static void addEntry(String inputBuffer, boolean isFromFile) throws IncorrectInputException {
+    //TODO[PARSER]: TEMPORARY. REMOVE LATER.
+    private String inputBuffer;
+
+    public AddCommand(String inputBuffer) {
+        this.inputBuffer = inputBuffer;
+    }
+
+    public void execute() throws IncorrectInputException {
 
         final Matcher matcher = ADD_ENTRY_COMMAND_FORMAT.matcher(inputBuffer);
 
@@ -36,11 +43,10 @@ public class AddCommand extends Command {
         final String remark = matcher.group("remark");
 
         EntryList.addEntry(new Entry(date, species, name, remark));
-        if (!isFromFile) {
-            Ui.entryAddedMessagePrinter();
-            Ui.printEntry(EntryList.getArraySize() - 1);
-            Ui.entryCountPrinter();
-        }
+
+        Ui.entryAddedMessagePrinter();
+        Ui.printEntry(EntryList.getArraySize() - 1);
+        Ui.entryCountPrinter();
     }
 }
 

--- a/src/main/java/seedu/wildwatch/command/Command.java
+++ b/src/main/java/seedu/wildwatch/command/Command.java
@@ -1,8 +1,12 @@
 package seedu.wildwatch.command;
 
+import seedu.wildwatch.exception.IncorrectInputException;
+
 /**
  * Command class for manipulating EntryList
  */
 public abstract class Command {
     public Command() {}
+
+    public abstract void execute() throws IncorrectInputException;
 }

--- a/src/main/java/seedu/wildwatch/command/DeleteCommand.java
+++ b/src/main/java/seedu/wildwatch/command/DeleteCommand.java
@@ -10,12 +10,16 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
+    private final int numberInput;
+
+    public DeleteCommand(int numberInput) {
+        this.numberInput = numberInput;
+    }
+
     /**
      * Deletes entry in the EntryList
-     *
-     * @param numberInput
      */
-    public static void deleteEntry(int numberInput) {
+    public void execute() {
         Ui.entryRemovedMessagePrinter();
         EntryList.deleteEntry(numberInput);
         Ui.entryCountPrinter();

--- a/src/main/java/seedu/wildwatch/command/FindCommand.java
+++ b/src/main/java/seedu/wildwatch/command/FindCommand.java
@@ -12,16 +12,21 @@ import java.util.ArrayList;
 /**
  * Handles the "find" command to search for tasks that contain a specific keyword.
  */
-public class FindCommand {
+public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
+    //TODO[PARSER]: SHOULD BE REMOVED AFTER IMPLEMENTING PARSER
+    private String inputBuffer;
+
+    public FindCommand(String inputBuffer) {
+        this.inputBuffer = inputBuffer;
+    }
+
     /**
      * Searches for tasks that contain the specified keyword and prints them.
-     *
-     * @param inputBuffer The full find command entered by the user.
      */
-    public static void findEntry(String inputBuffer) {
+    public void execute() {
         boolean hasMatch = false;
         String matchingWord = inputBuffer.substring(inputBuffer.indexOf("find") + 5).trim();
         ArrayList<Entry> entries = EntryList.getArray();

--- a/src/main/java/seedu/wildwatch/command/HelpCommand.java
+++ b/src/main/java/seedu/wildwatch/command/HelpCommand.java
@@ -66,7 +66,7 @@ public class HelpCommand extends Command {
     /**
      * Prints out help page
      */
-    public static void printHelpMessage() {
+    public void execute() {
         System.out.println(helpPage);
     }
 

--- a/src/main/java/seedu/wildwatch/command/SummaryCommand.java
+++ b/src/main/java/seedu/wildwatch/command/SummaryCommand.java
@@ -17,7 +17,14 @@ public class SummaryCommand extends Command {
 
     public static final String COMMAND_WORD = "summary";
 
-    public static Map<String, List<Entry>> groupEntriesBySpecies(List<Entry> entries) {
+    //TODO[PARSER]: REMOVE L8ER
+    private String inputBuffer;
+
+    public SummaryCommand(String inputBuffer) {
+        this.inputBuffer = inputBuffer;
+    }
+
+    private static Map<String, List<Entry>> groupEntriesBySpecies(List<Entry> entries) {
 
         Map<String, List<Entry>> map = new HashMap<String, List<Entry>>();
         for (Entry entry : entries) {
@@ -33,7 +40,7 @@ public class SummaryCommand extends Command {
         }
         return map;
     }
-    public static Map<String, List<Entry>> groupSpecieByName(List<Entry> filteredEntries) {
+    private static Map<String, List<Entry>> groupSpecieByName(List<Entry> filteredEntries) {
         Map<String, List<Entry>> filteredMap = new HashMap<String, List<Entry>>();
 
         for (Entry entry : filteredEntries) {
@@ -49,7 +56,7 @@ public class SummaryCommand extends Command {
         }
         return filteredMap;
     }
-    public static void showSummary(String inputBuffer) throws IncorrectInputException {
+    public void execute() throws IncorrectInputException {
         String argument = inputBuffer.replace("summary","").trim();
         String speciesName = argument;
         boolean hasArgument = !argument.isEmpty();

--- a/src/main/java/seedu/wildwatch/operation/EntryHandler.java
+++ b/src/main/java/seedu/wildwatch/operation/EntryHandler.java
@@ -32,19 +32,17 @@ public class EntryHandler {
         }
 
         //Functionalities
-        if (isFromFile && firstWord.equals(AddCommand.COMMAND_WORD)) {
-            AddCommand.addEntry(inputBuffer, isFromFile);
-        } else if (firstWord.equals(AddCommand.COMMAND_WORD)) {
-            AddCommand.addEntry(inputBuffer, false);
+        if (firstWord.equals(AddCommand.COMMAND_WORD)) {
+            new AddCommand(inputBuffer).execute();
         } else if (firstWord.equals(DeleteCommand.COMMAND_WORD) && hasInputInteger && !bufferScanner.hasNext()) {
             assert numberInput > 0 : "Entry number to delete should be positive";
-            DeleteCommand.deleteEntry(numberInput);
+            new DeleteCommand(numberInput).execute();
         } else if (firstWord.equals(FindCommand.COMMAND_WORD)) {
-            FindCommand.findEntry(inputBuffer);
+            new FindCommand(inputBuffer).execute();
         } else if (inputBuffer.equals(ListCommand.COMMAND_WORD)) {
             new ListCommand().execute();
         } else if (firstWord.equals(SummaryCommand.COMMAND_WORD)) {
-            SummaryCommand.showSummary(inputBuffer);
+            new SummaryCommand(inputBuffer).execute();
         } else {
             LOGGER.log(Level.WARNING, "Unknown input received: {0}. Throwing exception.", inputBuffer);
             throw new UnknownInputException(); //Unrecognizable by Parser

--- a/src/main/java/seedu/wildwatch/operation/InputHandler.java
+++ b/src/main/java/seedu/wildwatch/operation/InputHandler.java
@@ -24,7 +24,7 @@ public class InputHandler {
                 Ui.printHorizontalLines();
                 Ui.helpRequestMessagePrinter();
                 Ui.printHorizontalLines();
-                HelpCommand.printHelpMessage();
+                new HelpCommand().execute();
             } else {
                 Ui.printHorizontalLines();
                 ErrorHandler.handleError(inputBuffer);


### PR DESCRIPTION
Justification: 
* Parser will generate a `Command` which can be `.execute()`d
* Currently the abstract `Command` class isn't enforcing anything