### PR TITLE
Move routing functionality to EntryHandler

### DIFF
--- a/src/main/java/seedu/wildwatch/command/ByeCommand.java
+++ b/src/main/java/seedu/wildwatch/command/ByeCommand.java
@@ -6,7 +6,7 @@ import seedu.wildwatch.operation.ShutDown;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class ByeCommand {
+public class ByeCommand extends Command {
 
     public static final String COMMAND_WORD = "bye";
 
@@ -15,5 +15,9 @@ public class ByeCommand {
     public static void exitProgram() {
         LOGGER.log(Level.INFO, "Initiating shutdown procedures.");
         ShutDown.shutDown();
+    }
+
+    //TODO: figure out a way to get rid of this
+    public void execute() {
     }
 }

--- a/src/main/java/seedu/wildwatch/command/HelpCommand.java
+++ b/src/main/java/seedu/wildwatch/command/HelpCommand.java
@@ -67,6 +67,7 @@ public class HelpCommand extends Command {
      * Prints out help page
      */
     public void execute() {
+        System.out.println("No worries, I'm here to help!");
         System.out.println(helpPage);
     }
 

--- a/src/main/java/seedu/wildwatch/operation/EntryHandler.java
+++ b/src/main/java/seedu/wildwatch/operation/EntryHandler.java
@@ -4,11 +4,14 @@ import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import seedu.wildwatch.command.Command;
 import seedu.wildwatch.command.AddCommand;
 import seedu.wildwatch.command.DeleteCommand;
 import seedu.wildwatch.command.FindCommand;
+import seedu.wildwatch.command.HelpCommand;
 import seedu.wildwatch.command.ListCommand;
 import seedu.wildwatch.command.SummaryCommand;
+import seedu.wildwatch.command.ByeCommand;
 import seedu.wildwatch.exception.IncorrectInputException;
 import seedu.wildwatch.exception.UnknownInputException;
 
@@ -17,13 +20,15 @@ public class EntryHandler {
     private static final int DEFAULT_NUMBER_INPUT = -3710; //Number that can never be input in normal use of WildWatch
     private static final Logger LOGGER = Logger.getLogger(EntryHandler.class.getName());
 
-    public static void handleEntry(String inputBuffer, boolean isFromFile)
+    public static Command handleEntry(String inputBuffer)
             throws UnknownInputException, IncorrectInputException {
         LOGGER.log(Level.INFO, "Managing entry for input: {0}", inputBuffer);
         Scanner bufferScanner = new Scanner(inputBuffer);     //Scanner for the buffer
         String firstWord = bufferScanner.next();              //Stores first word in the input
+
         assert firstWord != null && !firstWord.isEmpty() : "First word shouldn't be null or empty";
 
+        //TODO: weird place to put this
         boolean hasInputInteger = bufferScanner.hasNextInt(); //Indicates that some integer was input
         int numberInput = DEFAULT_NUMBER_INPUT;               //Stores the number input
         if (hasInputInteger) {
@@ -33,16 +38,20 @@ public class EntryHandler {
 
         //Functionalities
         if (firstWord.equals(AddCommand.COMMAND_WORD)) {
-            new AddCommand(inputBuffer).execute();
+            return new AddCommand(inputBuffer);
         } else if (firstWord.equals(DeleteCommand.COMMAND_WORD) && hasInputInteger && !bufferScanner.hasNext()) {
             assert numberInput > 0 : "Entry number to delete should be positive";
-            new DeleteCommand(numberInput).execute();
+            return new DeleteCommand(numberInput);
         } else if (firstWord.equals(FindCommand.COMMAND_WORD)) {
-            new FindCommand(inputBuffer).execute();
+            return new FindCommand(inputBuffer);
         } else if (inputBuffer.equals(ListCommand.COMMAND_WORD)) {
-            new ListCommand().execute();
+            return new ListCommand();
         } else if (firstWord.equals(SummaryCommand.COMMAND_WORD)) {
-            new SummaryCommand(inputBuffer).execute();
+            return new SummaryCommand(inputBuffer);
+        } else if (firstWord.equals(HelpCommand.COMMAND_WORD)) {
+            return new HelpCommand();
+        } else if (firstWord.equals(ByeCommand.COMMAND_WORD)) {
+            return new ByeCommand();
         } else {
             LOGGER.log(Level.WARNING, "Unknown input received: {0}. Throwing exception.", inputBuffer);
             throw new UnknownInputException(); //Unrecognizable by Parser

--- a/src/main/java/seedu/wildwatch/operation/ErrorHandler.java
+++ b/src/main/java/seedu/wildwatch/operation/ErrorHandler.java
@@ -20,6 +20,7 @@ import seedu.wildwatch.exception.UnknownInputException;
 import seedu.wildwatch.exception.UnknownDateFormatException;
 import seedu.wildwatch.exception.IncorrectInputException;
 
+//TODO: this file should not exist
 public class ErrorHandler {
     private static final int DEFAULT_NUMBER_INPUT = -3710; //Number never input during normal use of WildWatch
     private static final Logger LOGGER = Logger.getLogger(ErrorHandler.class.getName());
@@ -28,7 +29,7 @@ public class ErrorHandler {
         boolean validInput = false;
         try {
             checkError(inputBuffer);
-            EntryHandler.handleEntry(inputBuffer, false);
+            EntryHandler.handleEntry(inputBuffer);
             validInput = true;
         } catch (EmptyInputException exception) {
             LOGGER.warning("Received an empty input.");

--- a/src/main/java/seedu/wildwatch/operation/InputHandler.java
+++ b/src/main/java/seedu/wildwatch/operation/InputHandler.java
@@ -1,7 +1,7 @@
 package seedu.wildwatch.operation;
 
+import seedu.wildwatch.command.Command;
 import seedu.wildwatch.command.ByeCommand;
-import seedu.wildwatch.command.HelpCommand;
 import seedu.wildwatch.entry.EntryList;
 import seedu.wildwatch.exception.IncorrectInputException;
 import seedu.wildwatch.exception.UnknownInputException;
@@ -18,27 +18,33 @@ public class InputHandler {
             String inputBuffer = Ui.inputRetriever(); //Retrieves input of user
             LOGGER.log(Level.INFO, "Input received: {0}", inputBuffer);
 
-            if (inputBuffer.equals(ByeCommand.COMMAND_WORD)) {        //Program exit
-                break;
-            } else if (inputBuffer.equals(HelpCommand.COMMAND_WORD)) {  //User request "help"
+            try {
+                Command command = EntryHandler.handleEntry(inputBuffer);
+
+                if (command instanceof ByeCommand) {
+                    break;
+                }
+
                 Ui.printHorizontalLines();
-                Ui.helpRequestMessagePrinter();
+                command.execute();
                 Ui.printHorizontalLines();
-                new HelpCommand().execute();
-            } else {
-                Ui.printHorizontalLines();
-                ErrorHandler.handleError(inputBuffer);
-                Ui.printHorizontalLines();
+
+            } catch (IncorrectInputException e) {
+                Ui.incorrectInputMessagePrinter();
+            } catch (UnknownInputException e) {
+                Ui.unknownInputMessagePrinter();
             }
-            EntryList.saveEntry();
         }
+
+        EntryList.saveEntry();
         ByeCommand.exitProgram();
     }
 
     public static void handleFileInput(String lineOfFile) {
         try {
-            EntryHandler.handleEntry(lineOfFile, true);
+            EntryHandler.handleEntry(lineOfFile);
         } catch (UnknownInputException | IncorrectInputException exception) {
+            //TODO: this function is no longer useful but this has to be moved somewhere
             Ui.corruptFileMessagePrinter();
             ShutDown.shutDown();
             System.exit(0);

--- a/src/main/java/seedu/wildwatch/operation/Ui.java
+++ b/src/main/java/seedu/wildwatch/operation/Ui.java
@@ -113,10 +113,6 @@ public class Ui {
         }
     }
 
-    public static void helpRequestMessagePrinter() {
-        System.out.println("No worries, I'm here to help!");
-    }
-
     public static void incorrectInputMessagePrinter() {
         System.out.println("OOPS!!! Format of command is incorrect.");
     }


### PR DESCRIPTION
Justification:
* So that routing won't be done in multiple places 
* `InputHandler` exclusively used for reading input in a loop, accepts `Command` from `EntryHandler` and executes it. 
* Some remaining `//TODO`s in the code but the more I drag this out the more painful it's going to be
* Error handling for each command should be done separately