### PR TITLE
Modify summary command to list entries

### DIFF
--- a/src/main/java/seedu/wildwatch/command/SummaryCommand.java
+++ b/src/main/java/seedu/wildwatch/command/SummaryCommand.java
@@ -79,7 +79,13 @@ public class SummaryCommand extends Command {
             SummaryCommandPrinter.printSummaryNameMessage(speciesName);
             List<Entry> filteredEntries = map.get(speciesName);
             Map<String, List<Entry>> filteredMap = groupSpecieByName(filteredEntries);
-            filteredMap.forEach((key, value) -> System.out.println(key + " - (" + value.size() + ")"));
+            filteredMap.forEach((key, value) -> {
+                System.out.println(key + " - (" + value.size() + ")");
+                for (Entry v : value) {
+                    System.out.println(v.entryString());
+                }
+            });
+
         } else {
             SummaryCommandPrinter.printSummarySpecieMessage();
             map.forEach((key, value) -> System.out.println(key + " - (" + value.size() + ")"));

--- a/src/main/java/seedu/wildwatch/entry/Entry.java
+++ b/src/main/java/seedu/wildwatch/entry/Entry.java
@@ -52,6 +52,11 @@ public class Entry {
     }
     //@@woodenclock
 
+    public String entryString() {
+        return String.format("Date: [%s] | Species: [%s] | Name: [%s] | Remark: [%s]",
+                getDate().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")), getSpecies(), getName(), getRemark());
+    }
+
     /**
      * Returns true if both entries have the same value for each field.
      */


### PR DESCRIPTION
Closes https://github.com/AY2324S1-CS2113T-W11-2/tp/issues/155. 
Modified so that it does the following instead: 
```
____________________________________________________________
>>> summary Annam Leaf Turtle
____________________________________________________________
Here is the data for the Annam Leaf Turtle, grouped by their names
Arie - (1)
Date: [02-03-2023] | Species: [Annam Leaf Turtle] | Name: [Arie] | Remark: []
Ariel - (2)
Date: [02-03-2023] | Species: [Annam Leaf Turtle] | Name: [Ariel] | Remark: [Injured left flipper]
Date: [02-02-2024] | Species: [Annam Leaf Turtle] | Name: [Ariel] | Remark: []
____________________________________________________________
```
tbh, I think rather than doing this it would be better to just add a line that says "use `find` command to find entries". 